### PR TITLE
Tighten Flippa role phrasing in hero intro.

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -47,7 +47,7 @@ const HeroSection = () => {
             >
             Apple Podcasts
             </a>,{" "} and other podcasting platforms |
-            Full-stack data scientist | Currently a Global M&amp;A Broker with{" "}
+            Full-stack data scientist | Global M&amp;A Broker with{" "}
             <a
               href="https://flippa.com/lps/lam-trinh"
               target="_blank"


### PR DESCRIPTION
Remove "Currently a" so the M&A broker line matches the other pipe-separated credentials.